### PR TITLE
Patched many-to-many support

### DIFF
--- a/src/server/router/nested.js
+++ b/src/server/router/nested.js
@@ -7,7 +7,7 @@ module.exports = () => {
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request query
   function get (req, res, next) {
     const prop = pluralize.singular(req.params.resource)
-    req.query[`${prop}Id`] = req.params.id
+    req.query[`${prop}Id_like`] = `\\b${req.params.id}\\b`
     req.url = `/${req.params.nested}`
     next()
   }
@@ -15,7 +15,7 @@ module.exports = () => {
   // Rewrite URL (/:resource/:id/:nested -> /:nested) and request body
   function post (req, res, next) {
     const prop = pluralize.singular(req.params.resource)
-    req.body[`${prop}Id`] = req.params.id
+    req.body[`${prop}Id_like`] = `\\b${req.params.id}\\b`
     req.url = `/${req.params.nested}`
     next()
   }


### PR DESCRIPTION
Hello,

First at all, thanks for your awesome project. In my work, I had some troubles with many-to-many and I fixed it by using regex in the nesting. With the code, it's compatible with an array of ids like with id.
I've opened this issue [#428](https://github.com/typicode/json-server/issues/428) some days ago.

Of course, you can probably do a better implementation but I think it's a good way.

I hope you will integrate the many-to-many feature :)

Thanks again.

Description:

Patched many-to-many feature.
In json file, it supports ids like this:
```xml
{
  post: [
  {
    "id": 1,
     "content": "blabla"
     "authorId": 1
  },
  {
     "id": 2,
     "content": "blabla",
     "authorId": 1
  }
  ],
  author: [
  {
    "id": 1,
    "postId": [1,2],
    "name": "John Doe"
  }
  ]
}
```